### PR TITLE
Pull request/771f3df1

### DIFF
--- a/examples/EResNN_CIFAR10.jl
+++ b/examples/EResNN_CIFAR10.jl
@@ -18,9 +18,10 @@ h    = [1.;1.;1.]
 
 TYPE = Float32;
 
-getConvKernel = (nImg,sK) -> getConvGEMMKernel(TYPE,nImg,sK);
+# getConvKernel = (nImg,sK) -> getConvGEMMKernel(TYPE,nImg,sK);
 # getConvKernel = (nImg,sK) -> getConvFFTKernel(TYPE,nImg,sK);
 #getConvKernel = (nImg,sK) -> getSparseConvKernel2D(TYPE,nImg,sK);
+getConvKernel = (nImg,sK) -> getConvMKLKernel(TYPE,nImg,sK);
 
 # opening layer
 K1 = getConvKernel(nImg,[3,3,cin,nc[1]]);

--- a/src/AbstractMeganetElement.jl
+++ b/src/AbstractMeganetElement.jl
@@ -175,6 +175,7 @@ Output:
 """
 function getJYOp(this::AbstractMeganetElement{T},theta::Array{T},Y::Array{T},tmp=nothing) where {T <: Number}
     nex    = div(length(Y),nFeatIn(this))
+    
     m      = nex*nDataOut(this)
     n      = length(Y);
     Amv    = x -> JYmv(this,x,theta,Y,tmp)
@@ -353,6 +354,7 @@ Output:
   J     - Jacobian, LinearOperator
 """
 function getJOp(this::AbstractMeganetElement{T},theta::Array{T},Y::Array{T},tmp=nothing) where {T <: Number}
+   
     nex    = div(length(Y),nFeatIn(this))
     m      = nex*nDataOut(this)
     nth    = length(theta)

--- a/src/Meganet.jl
+++ b/src/Meganet.jl
@@ -6,7 +6,7 @@ import JLD, BenchmarkTools
 
 include("AbstractMeganetElement.jl")
 
-include("activations/tanhActivation.jl")
+include("activations/reluActivation.jl")
 
 include("integrators/NN.jl")
 include("integrators/connector.jl")
@@ -17,7 +17,7 @@ include("kernelTypes/sparseKernel.jl")
 include("kernelTypes/convFFTKernel.jl");
 include("kernelTypes/convGEMMKernel.jl");
 include("kernelTypes/convCircKernel.jl");
-# include("kernelTypes/convDiagKernel.jl");
+include("kernelTypes/convMKLKernel.jl");
 
 
 

--- a/src/kernelTypes/callmkldnn.jl
+++ b/src/kernelTypes/callmkldnn.jl
@@ -1,0 +1,94 @@
+
+# export MKLDNNROOT=/home/shekht/dnn/install
+# export LD_LIBRARY_PATH=/home/shekht/dnn/install/lib
+
+# To compile the code:
+# g++ -std=c++11 -I${MKLDNNROOT}/include -L${MKLDNNROOT}/lib convolution.cpp convolutionT.cpp convolutionDeriv.cpp  -lmkldnn -lmklml_intel -liomp5 -O -fPIC -shared -o mkldnn.so
+using Meganet
+
+const mkldnnpath = "/home/moumita/Desktop/test/mkldnn.so"
+
+function convMKL( K::Array{Float32,4}, Y::Array{Float32,4} )
+   # Convoltion time vector
+   # K should be nk x nk x n2 x n1
+   # Y should be nImage2 x nImage1 x n2 x batch
+   # Output is nimage2, nimage1, n1, batch
+   
+   
+   nk, nk,  n2, n1 = size(K)
+   nimage2, nimage1, n2_2, batch = size(Y)
+   
+   if nk != 3 ; error("nk != 3") ; end
+   if n2 != n2_2 ; error("n2 != n2_2") ; end
+   
+   AY = Array{Float32}(nimage2, nimage1, n1, batch)
+   
+   ccall( (:Convolution, mkldnnpath),
+          Void, ( Int32,Int32,Int32,Int32,Int32,Int32, Ref{Float32},Ref{Float32},Ref{Float32} ),
+                  batch, nk, nimage1, nimage2, n1, n2,  Y, K,  AY)
+                   
+   return AY
+end  # function convMKL
+
+#----------------------------------------------------------------------------------
+
+function convTMKL( K::Array{Float32,4}, Y::Array{Float32,4} )
+   # Convoltion transpose time vector
+   # K should be nk, nk,  n2, n1
+   # Y should be nimage2, nimage1, n1, batch
+   # Output is nimage2, nimage1, n2, batch
+   
+   
+   nk, nk,  n2, n1 = size(K)
+   nimage2, nimage1, n1_2, batch = size(Y)
+   
+   if nk != 3 ; error("nk != 3") ; end
+   if n1 != n1_2 ; error("n1 != n1_2") ; end
+   
+   
+   ATY = Array{Float32}(nimage2, nimage1, n2, batch)
+   
+   ccall( (:ConvolutionT, mkldnnpath),
+          Void, ( Int32,Int32,Int32,Int32,Int32,Int32, Ref{Float32},Ref{Float32},Ref{Float32} ),
+                  batch, nk, nimage1, nimage2, n1, n2, ATY, K,  Y)
+                   
+   return ATY
+end  # function convTMKL
+
+#----------------------------------------------------------------------------------
+
+function convDerivMKL( sK::Array{Int}, Z::Array{Float32,4}, Y::Array{Float32,4} )
+   # Z should be nimage2, nimage1, n1, batch
+   # Y should be nimage2, nimage1, n2, batch
+   # Output is  nk, nk,  n2, n1
+   
+   nk, nk,  n2, n1 = sK
+   
+   nimage2, nimage1, n2_2, batch = size(Y)
+   nimage2, nimage1, n1_2, batch = size(Z)
+   
+   if nk != 3 ; error("nk != 3") ; end
+   if n1 != n1_2 || n2 != n2_2 ; error("n1 != n1_2 || n2 != n2_2") ; end
+   
+   ADY = Array{Float32}(nk, nk,  n2, n1)
+   
+   ccall( (:ConvolutionDeriv, mkldnnpath),
+          Void, ( Int32,Int32,Int32,Int32,Int32,Int32, Ref{Float32},Ref{Float32},Ref{Float32} ),
+                  batch, nk, nimage1, nimage2, n1, n2, Y, ADY,  Z)
+                   
+   return ADY
+end  # function convDerivMKL
+
+
+nImage = [64,64];
+sK = [3,3,32,16];
+K = randn(Float32, tuple(sK...));
+Y = randn(Float32, nImage[1]*nImage[2]*sK[4], 100);
+
+Kernel = getConvGEMMKernel(Float32, nImage,sK);
+
+@time ATY = ATmv(Kernel, K,Y);
+
+
+YY = reshape(Y, nImage[1],nImage[2],sK[4], 100 );
+@time ATY2 = convTMKL(K,YY);

--- a/src/kernelTypes/convMKLKernel.jl
+++ b/src/kernelTypes/convMKLKernel.jl
@@ -1,0 +1,211 @@
+export convMKLKernel,Amv,ATmv,getConvMKLKernel
+include("/home/moumita/.julia/v0.6/test/callmkldnn.jl")
+# include("/home/moumita/.julia/v0.6/Meganet/src/kernelTypes/convGEMMKernel.jl")
+using DistributedArrays
+mutable struct convMKLKernel{T} <: AbstractConvKernel{T}
+    nImg    		:: Array{Int,1}
+    sK      		:: Array{Int,1}
+	shiftX  		:: Array{Int,1}
+	shiftT  		:: Array{Int,1}
+	aux_sk3 		:: Array{T, 3}
+	aux_sk4 		:: Array{T, 3}
+	KK 				:: Array{Array{T,2}}
+
+end
+function getConvMKLKernel(TYPE::Type,nImg,sK)
+	
+	if sK[1] == 1 && sK[2] == 1
+		shiftX = [0;0];
+		shiftT = [0;0];
+	elseif sK[1] == 3 && sK[2] == 3
+		shiftX = [0;-1;0;0;1;0];
+		shiftT = [1;0;0;0;0;-1];
+	else
+		error("Code only supports 1X1 and 3X3 convolutions");
+	end
+	
+	aux_sk3 = zeros(TYPE,nImg[1],nImg[2],sK[3]);
+	aux_sk4 = zeros(TYPE,nImg[1],nImg[2],sK[4]);
+	
+	KK = Array{Array{TYPE,2}}(sK[1],sK[2]);
+	
+	return convMKLKernel{TYPE}(copy(nImg),copy(sK),shiftX,shiftT,aux_sk3,aux_sk4,KK);
+end
+
+function Amv(this::convMKLKernel{T},theta::Array{T},Y::Array{T}) where {T<:Number}
+    ## We assume that the data Y is held in the order XYCN.
+	println("AMV")
+	sK = this.sK;
+   
+    nImg = this.nImg;
+    nex   = div(numel(Y),prod(nImgIn(this)))
+    
+    if sK[1]!=3
+        
+        AY = Amv(this,theta,Y,1)
+    else
+        
+        Y     = reshape(Y,nImg[1],nImg[2],this.sK[3],nex);
+        K = reshape(theta, sK[1], sK[2], sK[3], sK[4])
+        AY = convMKL(K,Y);
+    end
+    AY_out = reshape(AY,nImg[1]*nImg[2]*sK[4], nex);
+    
+	return AY_out
+end
+function Amv(this::convMKLKernel{T},theta::Array{T},Y::Array{T}, hack::Int) where {T<:Number}
+## We assume that the data Y is held in the order XYCN.
+
+sK = this.sK;
+nImg = this.nImg;
+nex   = div(numel(Y),prod(nImgIn(this)))
+
+KK = this.KK
+
+# compute convolution
+Y     = reshape(Y,nImg[1],nImg[2],this.sK[3],nex);
+
+
+AY    = Array{T, 3}(nImg[1]*nImg[2],this.sK[4],nex);
+
+
+aux   = this.aux_sk3;
+AYk   = reshape(this.aux_sk4,nImg[1]*nImg[2],sK[4]);
+### reshape the kernels for gemm!:
+K = reshape(theta, sK[1], sK[2], sK[3], sK[4])
+    
+for k1 = 1:sK[1]
+    for k2 = 1:sK[2]
+        @inbounds KK[k1,k2] = K[k1,k2,:,:]';
+    end
+end
+
+for k = 1:nex
+    AYk[:] = zero(T)
+    AYk = multConv2Dblock(Y,KK, AYk,aux,this.shiftX,this.shiftT,k);
+    @inbounds AY[:,:,k] = AYk;
+end
+AY_out = reshape(AY,:,nex)
+
+return AY_out
+end
+
+function ATmv(this::convMKLKernel{T},theta::Array{T},Zin::Array{T}) where {T<:Number}
+	println("ATMV")
+	nImg  = this.nImg;
+	sK    = this.sK;
+    nex   =  div(numel(Zin),prod(nImgOut(this)));
+    
+    if sK[1]!=3
+       
+        ATZ = ATmv(this,theta,Zin,1)
+    else
+        
+        K     = reshape(theta, sK[1], sK[2], sK[3], sK[4]);
+       
+        Z     = reshape(Zin,nImg[1],nImg[2],sK[4],nex);
+        ATZ = convTMKL(K,Z);
+    end
+    ATZ_out = reshape(ATZ,:,nex);
+   
+    return ATZ_out
+end
+
+function ATmv(this::convMKLKernel{T},theta::Array{T},Zin::Array{T},hack::Int) where {T<:Number}
+	
+	nImg  = this.nImg;
+	sK    = this.sK;
+    nex   =  div(numel(Zin),prod(nImgOut(this)));
+    K     = reshape(theta, sK[1], sK[2], sK[3], sK[4]);
+	Z     = reshape(Zin,nImg[1],nImg[2],sK[4],nex);
+	aux   = this.aux_sk4;
+	# ATZ = this.ATZ
+	ATZk  = reshape(this.aux_sk3,nImg[1]*nImg[2],sK[3]); 
+	
+	
+	ATZ   = zeros(T,nImg[1]*nImg[2],sK[3],nex);
+	
+	### reshape the kernels for gemm!:
+	KK = this.KK
+	
+	for k1 = 1:sK[1]
+		for k2 = 1:sK[2]
+			@inbounds KK[k1,k2] = K[k1,k2,:,:];
+		end
+	end
+	## flipping:
+	KK = flipdim(flipdim(KK,2),1);
+	for k = 1:nex
+		ATZk[:] = zero(T)
+		ATZk = multConv2Dblock(Z,KK, ATZk,aux,this.shiftX,this.shiftT,k);
+		@inbounds ATZ[:,:,k] = ATZk;
+	end
+	ATZ_out = reshape(ATZ,:,nex);
+	
+	return ATZ_out
+end
+
+function Jthetamv(this::convMKLKernel{T},dtheta::Array{T},dummy::Array{T},Y::Array{T},temp=nothing) where {T<:Number}
+    nex    =  div(numel(Y),nFeatIn(this));
+    Z      = Amv(this,dtheta,Y);
+    return Z
+end
+
+function JthetaTmv(this::convMKLKernel{T}, Zin::Array{T}, dummy::Array{T}, Yin::Array{T}) where {T<:Number}
+	println("JThetaTMV")
+	sK = this.sK
+	nImg = this.nImg
+    nex   = div(numel(Yin),prod(nImgIn(this)))
+    K     = zeros(T, sK[1], sK[2], sK[3], sK[4])
+    
+    if sK[1]!=3
+        
+        dtheta = JthetaTmv(this,Zin,K,Yin,1)
+    else
+    Y     = reshape(Yin,nImg[1],nImg[2],this.sK[3],nex);
+    
+    
+    Z     = reshape(Zin,nImg[1],nImg[2],sK[4],nex);
+    
+    dtheta = convDerivMKL(K,Z,Y);
+    end
+    dtheta_out = reshape(dtheta, sK[1], sK[2], sK[3], sK[4])
+    
+    return dtheta_out
+end
+
+function JthetaTmv(this::convMKLKernel{T}, Zin::Array{T}, dummy::Array{T}, Yin::Array{T}, hack::Int) where {T<:Number}
+    # derivative of Z*(A(theta)*Y) w.r.t. theta
+   
+    sK = this.sK
+   nImg = this.nImg
+   nex   = div(numel(Yin),prod(nImgIn(this)))
+   # compute convolution
+   
+   Y     = reshape(Yin, nImg[1], nImg[2], this.sK[3], nex)
+   Z	  = reshape(Zin, nImg[1]*nImg[2], this.sK[4], nex)
+   
+   Zk    = reshape(this.aux_sk4, nImg[1]*nImg[2], this.sK[4]);
+   aux   = this.aux_sk3;
+   dtheta = zeros(T, sK[1], sK[2], sK[3], sK[4])
+   ### reshape the kernels for gemm!:
+   KK = this.KK
+   for k1 = 1:sK[1]
+       for k2 = 1:sK[2]
+           @inbounds KK[k1, k2] = zeros(T, sK[3], sK[4])
+       end
+   end
+   for k = 1:nex
+       getColumn!(Z, Zk, k)
+       multConv2Dblock(Y, KK,  Zk, aux, this.shiftX, this.shiftT, k, doDerivative = 1)
+   end
+   ### Assemble the kernels from gemm!:
+   for k1 = 1:sK[1]
+       for k2 = 1:sK[2]
+           @inbounds dtheta[k1, k2, :, :] = KK[k1, k2]
+       end
+   end
+   dtheta_out = reshape(dtheta, sK[1], sK[2], sK[3], sK[4])
+
+   return dtheta_out
+end

--- a/src/kernelTypes/convMKLKernel.jl
+++ b/src/kernelTypes/convMKLKernel.jl
@@ -1,6 +1,5 @@
 export convMKLKernel,Amv,ATmv,getConvMKLKernel
-include("/home/moumita/.julia/v0.6/test/callmkldnn.jl")
-# include("/home/moumita/.julia/v0.6/Meganet/src/kernelTypes/convGEMMKernel.jl")
+include(Pkg.dir("Meganet")*"/src/mkl/callmkldnn.jl")
 using DistributedArrays
 mutable struct convMKLKernel{T} <: AbstractConvKernel{T}
     nImg    		:: Array{Int,1}
@@ -34,7 +33,6 @@ end
 
 function Amv(this::convMKLKernel{T},theta::Array{T},Y::Array{T}) where {T<:Number}
     ## We assume that the data Y is held in the order XYCN.
-	println("AMV")
 	sK = this.sK;
    
     nImg = this.nImg;
@@ -91,7 +89,6 @@ return AY_out
 end
 
 function ATmv(this::convMKLKernel{T},theta::Array{T},Zin::Array{T}) where {T<:Number}
-	println("ATMV")
 	nImg  = this.nImg;
 	sK    = this.sK;
     nex   =  div(numel(Zin),prod(nImgOut(this)));
@@ -152,7 +149,6 @@ function Jthetamv(this::convMKLKernel{T},dtheta::Array{T},dummy::Array{T},Y::Arr
 end
 
 function JthetaTmv(this::convMKLKernel{T}, Zin::Array{T}, dummy::Array{T}, Yin::Array{T}) where {T<:Number}
-	println("JThetaTMV")
 	sK = this.sK
 	nImg = this.nImg
     nex   = div(numel(Yin),prod(nImgIn(this)))

--- a/src/layers/doubleSymLayer.jl
+++ b/src/layers/doubleSymLayer.jl
@@ -17,7 +17,7 @@ end
 
 function getDoubleSymLayer(TYPE::Type,K,nLayer::AbstractMeganetElement{T};
                            Bin=zeros(nFeatOut(K),0),Bout=zeros(nFeatIn(K),0),
-                           activation=tanhActivation,activation_inplace=tanhActivation!) where {T <: Number}
+                           activation=reluActivation,activation_inplace=reluActivation!) where {T <: Number}
     BinT = convert.(T, Bin)
     BoutT = convert.(T, Bout)
     return DoubleSymLayer(activation,activation_inplace,K,nLayer,BinT,BoutT);

--- a/src/layers/normLayer.jl
+++ b/src/layers/normLayer.jl
@@ -122,7 +122,6 @@ function JthetaTmv(this::normLayer{T},Z::Array{T},dummy::Array{T},theta::Array{T
 end
 
 function JYTmv(this::normLayer{T},Zin::Array{T},dummy::Array{T},theta::Array{T},Yin::Array{T},dA=nothing) where {T <: Number}
-
     nex = div(length(Yin),nFeatIn(this))
     nf  = this.nData[2]
 

--- a/src/layers/singleLayer.jl
+++ b/src/layers/singleLayer.jl
@@ -11,7 +11,7 @@ mutable struct singleLayer{T, TK <: AbstractConvKernel{T}, TN <: Union{batchNorm
 end
 
 function getSingleLayer(TYPE::Type, K,nLayer;Bin=zeros(TYPE,nFeatOut(K),0),Bout=zeros(TYPE,nFeatOut(K),0),
-                        activation=tanhActivation,activation_inplace=tanhActivation!)
+                        activation=reluActivation,activation_inplace=reluActivation!)
 	singleLayer(activation,activation_inplace,K,nLayer,Bin,Bout);
 end
 

--- a/src/mkl/callmkldnn.jl
+++ b/src/mkl/callmkldnn.jl
@@ -1,0 +1,76 @@
+
+# To compile the code:
+# g++ -std=c++11 -I${MKLDNNROOT}/include -L${MKLDNNROOT}/lib convolution.cpp convolutionT.cpp convolutionDeriv.cpp  -lmkldnn -lmklml_intel -liomp5 -O -fPIC -shared -o mkldnn.so
+const mkldnnpath = Pkg.dir("Meganet")*"/src/mkl/mkldnn.so"
+
+function convMKL( K::Array{Float32,4}, Y::Array{Float32,4} )
+   # Convoltion time vector
+   # K should be nk x nk x n2 x n1
+   # Y should be nImage2 x nImage1 x n2 x batch
+   # Output is nimage2, nimage1, n1, batch
+   
+   
+   nk, nk,  n2, n1 = size(K)
+   nimage2, nimage1, n2_2, batch = size(Y)
+   
+   if nk != 3 ; error("nk != 3") ; end
+   if n2 != n2_2 ; error("n2 != n2_2") ; end
+   
+   AY = Array{Float32}(nimage2, nimage1, n1, batch)
+   
+   ccall( (:Convolution, mkldnnpath),
+          Void, ( Int32,Int32,Int32,Int32,Int32,Int32, Ref{Float32},Ref{Float32},Ref{Float32} ),
+                  batch, nk, nimage1, nimage2, n1, n2,  Y, K,  AY)
+                   
+   return AY
+end  # function convMKL
+
+#----------------------------------------------------------------------------------
+
+function convTMKL( K::Array{Float32,4}, Y::Array{Float32,4} )
+   # Convoltion transpose time vector
+   # K should be nk, nk,  n2, n1
+   # Y should be nimage2, nimage1, n1, batch
+   # Output is nimage2, nimage1, n2, batch
+   
+   
+   nk, nk,  n2, n1 = size(K)
+   nimage2, nimage1, n1_2, batch = size(Y)
+   
+   if nk != 3 ; error("nk != 3") ; end
+   if n1 != n1_2 ; error("n1 != n1_2") ; end
+   
+   
+   ATY = Array{Float32}(nimage2, nimage1, n2, batch)
+   
+   ccall( (:ConvolutionT, mkldnnpath),
+          Void, ( Int32,Int32,Int32,Int32,Int32,Int32, Ref{Float32},Ref{Float32},Ref{Float32} ),
+                  batch, nk, nimage1, nimage2, n1, n2, ATY, K,  Y)
+                   
+   return ATY
+end  # function convTMKL
+
+#----------------------------------------------------------------------------------
+
+function convDerivMKL( sK::Array{Float32}, Z::Array{Float32,4}, Y::Array{Float32,4} )
+   # Z should be nimage2, nimage1, n1, batch
+   # Y should be nimage2, nimage1, n2, batch
+   # Output is  nk, nk,  n2, n1
+   
+   nk, nk,  n2, n1 = size(sK)
+   
+   nimage2, nimage1, n2_2, batch = size(Y)
+   nimage2, nimage1, n1_2, batch = size(Z)
+   
+   if nk != 3 ; error("nk != 3") ; end
+   if n1 != n1_2 || n2 != n2_2 ; error("n1 != n1_2 || n2 != n2_2") ; end
+   
+   ADY = Array{Float32}(nk, nk,  n2, n1)
+   
+   ccall( (:ConvolutionDeriv, mkldnnpath),
+          Void, ( Int32,Int32,Int32,Int32,Int32,Int32, Ref{Float32},Ref{Float32},Ref{Float32} ),
+                  batch, nk, nimage1, nimage2, n1, n2, Y, ADY,  Z)
+                   
+   return ADY
+end  # function convDerivMKL
+

--- a/src/mkl/convolution.cpp
+++ b/src/mkl/convolution.cpp
@@ -1,0 +1,162 @@
+/*******************************************************************************
+* Copyright 2016-2017 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include <iostream>
+#include <numeric>
+#include <string>
+#include "mkldnn.hpp"
+
+using namespace mkldnn;
+using namespace std;
+
+extern "C"
+{
+
+void Convolution( const int batch,
+                  const int nk,
+                  const int nimage1,
+                  const int nimage2,
+                  const int n1, const int n2, 
+                  float* net_src,       // Y (batch, n2, nimage1, nimage2)
+                  float* conv_weights,  // K (n1, n2, nk, nk)
+                  float* net_dst )   //      (batch, n1, nimage1, nimage2)  Output
+  {                   
+    auto cpu_engine = engine(engine::cpu, 0);
+
+    const auto srcformat     = memory::format::nchw;
+    const auto weightsformat = memory::format::oihw;
+  //  const auto srcformat     = memory::format::nhwc;
+  //  const auto weightsformat = memory::format::hwio;
+
+    //std::vector<float> net_src(batch * 3 * 227 * 227);
+    //std::vector<float> net_dst(batch * 96 * 27 * 27);
+
+    /* AlexNet: conv
+     * {batch, 3, 227, 227} (x) {96, 3, 11, 11} -> {batch, 96, 227, 227}
+     * strides: {1, 1}
+     */
+    memory::dims conv_src_tz = {batch, n2, nimage1, nimage2};
+  //  memory::dims conv_src_tz = {batch, nimage1, nimage2, n2};
+    memory::dims conv_weights_tz = {n1, n2, nk, nk};
+  //  memory::dims conv_weights_tz = {nk, nk, n1, n2};
+    memory::dims conv_bias_tz = {n1};
+    memory::dims conv_dst_tz = {batch, n1, nimage1, nimage2};
+ //   memory::dims conv_dst_tz = {batch, nimage1, nimage2, n1};
+    memory::dims conv_strides = {1, 1};
+    auto conv_padding = {1, 1};
+
+    vector<float> conv_bias(std::accumulate(conv_bias_tz.begin(),
+        conv_bias_tz.end(), 1, std::multiplies<uint32_t>()));
+
+    /* create memory for user data */
+    auto conv_user_src_memory = memory({{{conv_src_tz}, memory::data_type::f32,
+        srcformat}, cpu_engine}, net_src);
+    auto conv_user_weights_memory = memory({{{conv_weights_tz},
+        memory::data_type::f32, weightsformat}, cpu_engine},
+        conv_weights);
+    auto conv_user_bias_memory = memory({{{conv_bias_tz},
+        memory::data_type::f32, memory::format::x}, cpu_engine},
+        conv_bias.data());
+
+    /* create memory descriptors for convolution data w/ no specified format */
+    auto conv_src_md = memory::desc({conv_src_tz}, memory::data_type::f32,
+        memory::format::any);
+    auto conv_bias_md = memory::desc({conv_bias_tz}, memory::data_type::f32,
+        memory::format::any);
+    auto conv_weights_md = memory::desc({conv_weights_tz},
+        memory::data_type::f32, memory::format::any);
+
+
+    auto conv_user_dst_memory = memory({{{conv_dst_tz}, memory::data_type::f32,
+        srcformat}, cpu_engine}, net_dst );
+
+    auto conv_dst_md = memory::desc({conv_dst_tz}, memory::data_type::f32,
+        memory::format::any);
+
+    
+
+    /* create a convolution */
+    auto conv_desc = convolution_forward::desc(prop_kind::forward,
+        convolution_direct, conv_src_md, conv_weights_md, conv_bias_md,
+        conv_dst_md, conv_strides, conv_padding, conv_padding,
+        padding_kind::zero);
+    auto conv_prim_desc =
+        convolution_forward::primitive_desc(conv_desc, cpu_engine);
+
+
+    auto conv_dst_memory = conv_user_dst_memory;
+    if (memory::primitive_desc(conv_prim_desc.dst_primitive_desc()) !=
+        conv_user_dst_memory.get_primitive_desc()) {
+        conv_dst_memory = memory(conv_prim_desc.dst_primitive_desc());
+    }
+
+
+    std::vector<primitive> net;
+
+    /* create reorders between user and data if it is needed and
+     *  add it to net before convolution */
+    auto conv_src_memory = conv_user_src_memory;
+    if (memory::primitive_desc(conv_prim_desc.src_primitive_desc()) !=
+        conv_user_src_memory.get_primitive_desc()) {
+        conv_src_memory = memory(conv_prim_desc.src_primitive_desc());
+        net.push_back(reorder(conv_user_src_memory, conv_src_memory));
+    }
+
+    auto conv_weights_memory = conv_user_weights_memory;
+    if (memory::primitive_desc(conv_prim_desc.weights_primitive_desc()) !=
+        conv_user_weights_memory.get_primitive_desc()) {
+        conv_weights_memory = memory(conv_prim_desc.weights_primitive_desc());
+        net.push_back(reorder(conv_user_weights_memory, conv_weights_memory));
+    }
+
+
+
+
+    /* create convolution primitive and add it to net */
+    net.push_back(convolution_forward(conv_prim_desc, conv_src_memory,
+        conv_weights_memory, conv_user_bias_memory, conv_dst_memory));
+
+
+    if (conv_dst_memory != conv_user_dst_memory) {
+        net.push_back(reorder(conv_dst_memory, conv_user_dst_memory));
+    }
+
+
+
+    stream(stream::kind::eager).submit(net).wait();
+}  // Convolution
+
+
+}  // extern "C"
+
+
+// int main(int argc, char **argv) {
+//     try {
+
+//         const int batch = 8, nK=3, nimage=227, n1=96, n2=3;
+
+//         vector<float> net_src(batch * n2 * nimage * nimage);
+//         vector<float> conv_weights(n1 * n2 * nK * nK);
+//         vector<float> net_dst(batch * n1 * nimage * nimage);
+
+//         Convolution( batch, nK, nimage,nimage, n1, n2, net_src.data(), conv_weights.data(), net_dst.data() );
+//     }
+//     catch(error& e) {
+//         std::cerr << "status: " << e.status << std::endl;
+//         std::cerr << "message: " << e.message << std::endl;
+//     }
+//     return 0;
+// }

--- a/src/mkl/convolutionDeriv.cpp
+++ b/src/mkl/convolutionDeriv.cpp
@@ -1,0 +1,186 @@
+/*******************************************************************************
+* Copyright 2016-2017 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include <iostream>
+#include <numeric>
+#include <string>
+#include "mkldnn.hpp"
+
+using namespace mkldnn;
+using namespace std;
+
+extern "C"
+{
+
+void ConvolutionDeriv( const int batch,
+                   const int nk,
+                   const int nimage1,
+                   const int nimage2,
+                   const int n1, const int n2, 
+                   float* net_src,       // Y (batch, n2, nimage1, nimage2)
+                   float* conv_weights,  // K (n1, n2, nk, nk) Output
+                   float* net_dst )   //      (batch, n1, nimage1, nimage2)  
+  {                   
+    // NOTE that in the input, src is actually dst and dst is src !!!
+
+    auto cpu_engine = engine(engine::cpu, 0);
+
+    const auto srcformat     = memory::format::nchw;
+    const auto weightsformat = memory::format::oihw;
+
+
+    /* AlexNet: conv
+     * {batch, 3, 227, 227} (x) {96, 3, 11, 11} -> {batch, 96, 227, 227}
+     * strides: {1, 1}
+     */
+    memory::dims conv_src_tz_f = {batch, n2, nimage1, nimage2};
+    memory::dims conv_src_tz = {batch, n2, nimage1, nimage2};
+
+    memory::dims conv_weights_tz = {n1, n2, nk, nk};
+    memory::dims conv_bias_tz = {n1};
+
+    memory::dims conv_dst_tz_f = {batch, n1, nimage1, nimage2};
+    memory::dims conv_dst_tz = {batch, n1, nimage1, nimage2};
+
+    memory::dims conv_strides = {1, 1};
+    auto conv_padding = {1, 1};
+
+    vector<float> conv_bias(std::accumulate(conv_bias_tz.begin(),
+        conv_bias_tz.end(), 1, std::multiplies<uint32_t>()));
+
+    /* create memory for user data */
+    auto conv_user_src_memory = memory({{{conv_src_tz}, memory::data_type::f32,
+        srcformat}, cpu_engine}, net_src);
+    auto conv_user_weights_memory = memory({{{conv_weights_tz},
+        memory::data_type::f32, weightsformat}, cpu_engine},
+        conv_weights);
+    auto conv_user_bias_memory = memory({{{conv_bias_tz},
+        memory::data_type::f32, memory::format::x}, cpu_engine},
+        conv_bias.data());
+
+    /* create memory descriptors for convolution data w/ no specified format */
+    auto conv_src_md_f = memory::desc({conv_src_tz_f}, memory::data_type::f32,
+        memory::format::any);
+    auto conv_src_md = memory::desc({conv_src_tz}, memory::data_type::f32,
+        memory::format::any);
+    auto conv_bias_md = memory::desc({conv_bias_tz}, memory::data_type::f32,
+        memory::format::any);
+    auto conv_weights_md = memory::desc({conv_weights_tz},
+        memory::data_type::f32, memory::format::any);
+
+
+    auto conv_user_dst_memory = memory({{{conv_dst_tz}, memory::data_type::f32,
+        srcformat}, cpu_engine}, net_dst );
+
+    auto conv_dst_md_f = memory::desc({conv_dst_tz_f}, memory::data_type::f32,
+        memory::format::any);
+    auto conv_dst_md = memory::desc({conv_dst_tz}, memory::data_type::f32,
+        memory::format::any);
+
+    
+
+    /* create a convolution */
+    auto conv_desc = convolution_forward::desc(prop_kind::forward,
+        convolution_direct, conv_src_md_f, conv_weights_md, conv_bias_md,
+        conv_dst_md_f, conv_strides, conv_padding, conv_padding,
+        padding_kind::zero);
+    auto conv_prim_desc =
+        convolution_forward::primitive_desc(conv_desc, cpu_engine);
+
+    auto conv_back_desc = convolution_backward_weights::desc(  //prop_kind::forward,
+        convolution_direct, conv_src_md, conv_weights_md,  conv_bias_md,
+        conv_dst_md, conv_strides, conv_padding, conv_padding,
+        padding_kind::zero);
+    auto conv_back_prim_desc =
+        convolution_backward_weights::primitive_desc(conv_back_desc, cpu_engine, conv_prim_desc);
+
+
+
+
+
+    auto conv_weights_memory = conv_user_weights_memory;
+    if (memory::primitive_desc(conv_back_prim_desc.diff_weights_primitive_desc()) !=
+        conv_user_weights_memory.get_primitive_desc()) {
+        conv_weights_memory = memory(conv_back_prim_desc.diff_weights_primitive_desc());
+    }
+
+
+    std::vector<primitive> net;
+
+    /* create reorders between user and data if it is needed and
+     *  add it to net before convolution */
+    auto conv_src_memory = conv_user_src_memory;
+    if (memory::primitive_desc(conv_back_prim_desc.src_primitive_desc()) !=
+        conv_user_src_memory.get_primitive_desc()) {
+        conv_src_memory = memory(conv_back_prim_desc.src_primitive_desc());
+        net.push_back(reorder(conv_user_src_memory, conv_src_memory));
+       // cout << "reorder conv_user_src_memory" << endl; ///
+    }
+
+    auto conv_dst_memory = conv_user_dst_memory;
+    if (memory::primitive_desc(conv_back_prim_desc.diff_dst_primitive_desc()) !=
+        conv_user_dst_memory.get_primitive_desc()) {
+        conv_dst_memory = memory(conv_back_prim_desc.diff_dst_primitive_desc());
+        net.push_back(reorder(conv_user_dst_memory, conv_dst_memory));
+      //  cout << "reorder conv_user_dst_memory" << endl; ///
+    }
+
+
+
+
+    /* create convolution primitive and add it to net */
+    net.push_back(convolution_backward_weights(conv_back_prim_desc,
+                  conv_src_memory, conv_dst_memory,
+                  conv_weights_memory, conv_user_bias_memory ));  
+
+
+    if (conv_weights_memory != conv_user_weights_memory) {
+        net.push_back(reorder(conv_weights_memory, conv_user_weights_memory));
+       // cout << "reorder conv_weights_memory" << endl; ///
+    }
+
+
+
+    stream(stream::kind::eager).submit(net).wait();
+}  // ConvolutionDeriv
+
+
+}  // extern "C"
+
+
+ // int main(int argc, char **argv) {
+ //    try {
+
+ //       // const int batch = 8, nK=3, nimage=227, n1=96, n2=3;
+ //       // const int batch = 8, nK=3, nimage=227, n1=10, n2=10;
+ //        const int batch = 8, nK=3, nimage=50, n1=16, n2=32;
+
+ //        vector<float> net_src(batch * n2 * nimage * nimage, 2.f);
+ //        vector<float> conv_weights(n1 * n2 * nK * nK, 4.f);
+ //        vector<float> net_dst(batch * n1 * nimage * nimage, 3.f);
+
+ //        cout << net_src[2] << " " << conv_weights[2] << " "  << net_dst[2] << " "  << endl;
+
+ //        ConvolutionDeriv( batch, nK, nimage,nimage, n1, n2, net_src.data(), conv_weights.data(), net_dst.data() );
+
+ //        cout << net_src[2] << " " << conv_weights[2] << " "  << net_dst[2] << " "  << endl;
+ //    }
+ //    catch(error& e) {
+ //        std::cerr << "status: " << e.status << std::endl;
+ //        std::cerr << "message: " << e.message << std::endl;
+ //    }
+ //    return 0;
+ //}

--- a/src/mkl/convolutionT.cpp
+++ b/src/mkl/convolutionT.cpp
@@ -1,0 +1,186 @@
+/*******************************************************************************
+* Copyright 2016-2017 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include <iostream>
+#include <numeric>
+#include <string>
+#include "mkldnn.hpp"
+
+using namespace mkldnn;
+using namespace std;
+
+extern "C"
+{
+   
+void ConvolutionT( const int batch,
+                   const int nk,
+                   const int nimage1,
+                   const int nimage2,
+                   const int n1, const int n2, 
+                   float* net_src,       // Y (batch, n2, nimage1, nimage2)
+                   float* conv_weights,  // K (n1, n2, nk, nk)
+                   float* net_dst )   //      (batch, n1, nimage1, nimage2)  Output
+  {                   
+    // NOTE that in the input, src is actually dst and dst is src !!!
+
+    auto cpu_engine = engine(engine::cpu, 0);
+
+    const auto srcformat     = memory::format::nchw;
+    const auto weightsformat = memory::format::oihw;
+
+
+    /* AlexNet: conv
+     * {batch, 3, 227, 227} (x) {96, 3, 11, 11} -> {batch, 96, 227, 227}
+     * strides: {1, 1}
+     */
+    memory::dims conv_src_tz_f = {batch, n2, nimage1, nimage2};
+    memory::dims conv_src_tz = {batch, n2, nimage1, nimage2};
+
+    memory::dims conv_weights_tz = {n1, n2, nk, nk};
+    memory::dims conv_bias_tz = {n1};
+
+    memory::dims conv_dst_tz_f = {batch, n1, nimage1, nimage2};
+    memory::dims conv_dst_tz = {batch, n1, nimage1, nimage2};
+
+    memory::dims conv_strides = {1, 1};
+    auto conv_padding = {1, 1};
+
+    vector<float> conv_bias(std::accumulate(conv_bias_tz.begin(),
+        conv_bias_tz.end(), 1, std::multiplies<uint32_t>()));
+
+    /* create memory for user data */
+    auto conv_user_src_memory = memory({{{conv_src_tz}, memory::data_type::f32,
+        srcformat}, cpu_engine}, net_src);
+    auto conv_user_weights_memory = memory({{{conv_weights_tz},
+        memory::data_type::f32, weightsformat}, cpu_engine},
+        conv_weights);
+    auto conv_user_bias_memory = memory({{{conv_bias_tz},
+        memory::data_type::f32, memory::format::x}, cpu_engine},
+        conv_bias.data());
+
+    /* create memory descriptors for convolution data w/ no specified format */
+    auto conv_src_md_f = memory::desc({conv_src_tz_f}, memory::data_type::f32,
+        memory::format::any);
+    auto conv_src_md = memory::desc({conv_src_tz}, memory::data_type::f32,
+        memory::format::any);
+    auto conv_bias_md = memory::desc({conv_bias_tz}, memory::data_type::f32,
+        memory::format::any);
+    auto conv_weights_md = memory::desc({conv_weights_tz},
+        memory::data_type::f32, memory::format::any);
+
+
+    auto conv_user_dst_memory = memory({{{conv_dst_tz}, memory::data_type::f32,
+        srcformat}, cpu_engine}, net_dst );
+
+    auto conv_dst_md_f = memory::desc({conv_dst_tz_f}, memory::data_type::f32,
+        memory::format::any);
+    auto conv_dst_md = memory::desc({conv_dst_tz}, memory::data_type::f32,
+        memory::format::any);
+
+    
+
+    /* create a convolution */
+    auto conv_desc = convolution_forward::desc(prop_kind::forward,
+        convolution_direct, conv_src_md_f, conv_weights_md, conv_bias_md,
+        conv_dst_md_f, conv_strides, conv_padding, conv_padding,
+        padding_kind::zero);
+    auto conv_prim_desc =
+        convolution_forward::primitive_desc(conv_desc, cpu_engine);
+
+    auto conv_back_desc = convolution_backward_data::desc(  //prop_kind::forward,
+        convolution_direct, conv_src_md, conv_weights_md,  //conv_bias_md,
+        conv_dst_md, conv_strides, conv_padding, conv_padding,
+        padding_kind::zero);
+    auto conv_back_prim_desc =
+        convolution_backward_data::primitive_desc(conv_back_desc, cpu_engine, conv_prim_desc);
+
+
+
+
+    auto conv_src_memory = conv_user_src_memory;
+    if (memory::primitive_desc(conv_back_prim_desc.diff_src_primitive_desc()) !=
+        conv_user_src_memory.get_primitive_desc()) {
+        conv_src_memory = memory(conv_back_prim_desc.diff_src_primitive_desc());
+    }
+
+
+    std::vector<primitive> net;
+
+    
+
+    /* create reorders between user and data if it is needed and
+     *  add it to net before convolution */
+    auto conv_dst_memory = conv_user_dst_memory;
+    if (memory::primitive_desc(conv_back_prim_desc.diff_dst_primitive_desc()) !=
+        conv_user_dst_memory.get_primitive_desc()) {
+        conv_dst_memory = memory(conv_back_prim_desc.diff_dst_primitive_desc());
+        net.push_back(reorder(conv_user_dst_memory, conv_dst_memory));
+      //  cout << "reorder conv_user_dst_memory" << endl; ///
+    }
+
+    auto conv_weights_memory = conv_user_weights_memory;
+    if (memory::primitive_desc(conv_back_prim_desc.weights_primitive_desc()) !=
+        conv_user_weights_memory.get_primitive_desc()) {
+        conv_weights_memory = memory(conv_back_prim_desc.weights_primitive_desc());
+        net.push_back(reorder(conv_user_weights_memory, conv_weights_memory));
+       // cout << "reorder conv_weights_memory" << endl; ///
+    }
+
+
+
+
+    /* create convolution primitive and add it to net */
+    net.push_back(convolution_backward_data(conv_back_prim_desc, conv_dst_memory,
+        conv_weights_memory, conv_src_memory));   // conv_user_bias_memory
+
+
+    if (conv_src_memory != conv_user_src_memory) {
+        net.push_back(reorder(conv_src_memory, conv_user_src_memory));
+       // cout << "reorder conv_src_memory" << endl; ///
+    }
+
+
+
+    stream(stream::kind::eager).submit(net).wait();
+}  // ConvolutionT
+
+
+}  // extern "C"
+
+
+ int main(int argc, char **argv) {
+     try {
+
+         //const int batch = 8, nK=3, nimage=227, n1=96, n2=3;
+         const int batch = 8, nK=3, nimage=50, n1=16, n2=32;
+
+         vector<float> net_src(batch * n2 * nimage * nimage, 2.f);
+         vector<float> conv_weights(n1 * n2 * nK * nK, 4.f);
+         vector<float> net_dst(batch * n1 * nimage * nimage, 3.f);
+
+         cout << net_src[2] << " " << conv_weights[2] << " "  << net_dst[2] << " "  << endl;
+
+         ConvolutionT( batch, nK, nimage,nimage, n1, n2, net_src.data(), conv_weights.data(), net_dst.data() );
+
+         cout << net_src[2] << " " << conv_weights[2] << " "  << net_dst[2] << " "  << endl;
+
+     }
+     catch(error& e) {
+         std::cerr << "status: " << e.status << std::endl;
+         std::cerr << "message: " << e.message << std::endl;
+     }
+     return 0;
+ }

--- a/src/mkl/libiomp5.so
+++ b/src/mkl/libiomp5.so
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:16a72f3c0088294b85bdfc495cc3842a5ee465ec63aee0fb8f2652d169148cfd
+size 1842723

--- a/src/mkl/mkldnn.so
+++ b/src/mkl/mkldnn.so
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:864d3bed79e03c4169365f27f9d89b0cb3737be1c289d30bf5a6747ad0cf6a3e
+size 123408

--- a/src/mkl/testDeriv.jl
+++ b/src/mkl/testDeriv.jl
@@ -1,0 +1,19 @@
+using Meganet
+
+
+nImage = [64,64];
+sK = [3,3,32,64];
+batch = 100
+K = randn(Float32, tuple(sK...));
+Y = randn(Float32, nImage[1]*nImage[2]*sK[3], batch)
+Z = randn(Float32, nImage[1]*nImage[2]*sK[4], batch)
+
+Kernel = getConvGEMMKernel(Float32, nImage,sK);
+
+@time ADY = JthetaTmv(Kernel, Z, 0,Y);
+
+
+YY = reshape(Y, nImage[1],nImage[2],sK[3], batch)
+ZZ = reshape(Z, nImage[1],nImage[2],sK[4], batch)
+@time ADY2 = convDerivMKL(sK, ZZ,YY);
+

--- a/src/mkl/testT.jl
+++ b/src/mkl/testT.jl
@@ -1,0 +1,16 @@
+using Meganet
+
+
+nImage = [64,64];
+sK = [3,3,32,16];
+K = randn(Float32, tuple(sK...));
+Y = randn(Float32, nImage[1]*nImage[2]*sK[4], 100);
+
+Kernel = getConvGEMMKernel(Float32, nImage,sK);
+
+@time ATY = ATmv(Kernel, K,Y);
+
+
+YY = reshape(Y, nImage[1],nImage[2],sK[4], 100 );
+@time ATY2 = convTMKL(K,YY);
+

--- a/test/kernel/convMKLKernelTest.jl
+++ b/test/kernel/convMKLKernelTest.jl
@@ -1,0 +1,42 @@
+using Base.Test
+using Meganet
+using LinearOperators
+
+
+nImg = [8,10]
+sK   = [3,3,2,4]
+for TYPE=[Float64,Float32]
+    K = getConvMKLKernel(TYPE,nImg,sK)
+
+    @testset  "adjoint test $TYPE" begin
+	nex = 2;
+    theta = initTheta(K)
+    A     = getOp(K,theta);
+    v     = randn(TYPE,nFeatIn(K),nex)
+    w     = randn(TYPE,nFeatOut(K),nex)
+	
+    t1    = dot(w,A*v)
+    t2    = dot(v,A'*w)
+    # println("adjointTest t1=$t1\t t2=$t2")
+    println("t1", t1)
+    println("t2", t2)
+    @test norm(t1-t2)/norm(t1) < 1e3*eps(TYPE)
+    end
+
+    @testset "derivative Test" begin
+    th  = initTheta(K);
+    dth = initTheta(K);
+    nex = 2;
+    Y  = randn(TYPE,nFeatIn(K),nex);
+    Z  = randn(TYPE,nFeatOut(K),nex);
+
+    t1 = vec(Z)'*vec(Jthetamv(K,dth,th,Y));
+    t2 = vec(dth)'*vec(JthetaTmv(K,Z,th,Y));
+    # println("derivativeTest t1=$t1\t t2=$t2")
+    @test norm(t1-t2)/norm(t2) < 1e3*eps(TYPE)
+    end
+end
+
+
+
+

--- a/test/kernel/runtests.jl
+++ b/test/kernel/runtests.jl
@@ -13,3 +13,7 @@ end
 @testset "convGEMMKernel" begin
 include("convGEMMKernelTest.jl")
 end
+
+@testset "convMKLKernel" begin
+include("convMKLKernelTest.jl")
+end


### PR DESCRIPTION
Will remove mkl files from src/kernelTypes/ (they are now in /src/mkl/*)

Need to manually copy a large *.so file into src/mkl (too big to transfer on git right now).

MKL library is compiled for Float32 - therefore Float64 doesn't work for now. May want to revisit this later.